### PR TITLE
feat(monitoring): Micrometer + Prometheus + Grafana 모니터링 연동 #23

### DIFF
--- a/apigateway-service/build.gradle
+++ b/apigateway-service/build.gradle
@@ -45,6 +45,9 @@ dependencies {
 	// Cloud Bus
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.cloud:spring-cloud-starter-bus-amqp'
+	
+	// Prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 dependencyManagement {

--- a/apigateway-service/src/main/java/com/github/syann97/toymsa/apigatewayservice/filter/AuthorizationHeaderFilter.java
+++ b/apigateway-service/src/main/java/com/github/syann97/toymsa/apigatewayservice/filter/AuthorizationHeaderFilter.java
@@ -39,6 +39,11 @@ public class AuthorizationHeaderFilter extends AbstractGatewayFilterFactory<Auth
 	public GatewayFilter apply(Config config) {
 		return (exchange, chain) -> {
 			ServerHttpRequest request = exchange.getRequest();
+			String path = request.getURI().getPath();
+
+			if (path.startsWith("/user-service/actuator/")) {
+				return chain.filter(exchange);
+			}
 
 			if (!request.getHeaders().containsKey(HttpHeaders.AUTHORIZATION)) {
 				return onError(exchange, "No authorization header", HttpStatus.UNAUTHORIZED);

--- a/apigateway-service/src/main/resources/application.yml
+++ b/apigateway-service/src/main/resources/application.yml
@@ -47,6 +47,14 @@ spring:
               filters:
                 - RemoveRequestHeader=Cookie
                 - RewritePath=/user-service/(?<segment>.*), /$\{segment}
+            - id: user-service-actuator
+              uri: lb://USER-SERVICE
+              predicates:
+                - Path=/user-service/actuator/**
+                - Method=GET
+              filters:
+                - RemoveRequestHeader=Cookie
+                - RewritePath=/user-service/(?<segment>.*), /$\{segment}
             - id: user-service
               uri: lb://USER-SERVICE
               predicates:
@@ -103,3 +111,5 @@ management:
           - info
           - httpexchanges
           - busrefresh
+          - prometheus
+          - metrics

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -52,6 +52,9 @@ dependencies {
 
 	// Feign Micrometer
 	implementation 'io.github.openfeign:feign-micrometer'
+
+	// Prometheus
+	implementation 'io.micrometer:micrometer-registry-prometheus'
 }
 
 dependencyManagement {

--- a/order-service/src/main/resources/application.yml
+++ b/order-service/src/main/resources/application.yml
@@ -43,8 +43,19 @@ management:
     tracing:
       endpoint: "http://localhost:9411/api/v2/spans"
 
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - httptrace
+          - info
+          - prometheus
+          - metrics
+
 
 logging:
   level:
     org.springframework.security: DEBUG
     com.github.syann97.toymsa.userservice.client: DEBUG
+

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -65,6 +65,10 @@ dependencies {
 
     // Feign Micrometer
     implementation 'io.github.openfeign:feign-micrometer'
+
+    // Prometheus
+    implementation 'io.micrometer:micrometer-registry-prometheus'
+    implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 dependencyManagement {

--- a/user-service/src/main/java/com/github/syann97/toymsa/userservice/controller/UserController.java
+++ b/user-service/src/main/java/com/github/syann97/toymsa/userservice/controller/UserController.java
@@ -26,6 +26,7 @@ import com.github.syann97.toymsa.userservice.jpa.UserRepository;
 import com.github.syann97.toymsa.userservice.service.UserService;
 import com.github.syann97.toymsa.userservice.vo.UserVo;
 
+import io.micrometer.core.annotation.Timed;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
@@ -49,6 +50,7 @@ public class UserController {
 	}
 
 	@GetMapping("/health-check") // http://localhost:60000/health-check
+	@Timed(value = "users.status", longTask = true)
 	public String status() {
 		return String.format("It's Working in User Service"
 			+ ", port(local.server.port)=" + environment.getProperty("local.server.port")
@@ -61,6 +63,7 @@ public class UserController {
 	}
 
 	@GetMapping("/welcome")
+	@Timed(value = "users.welcome", longTask = true)
 	public String welcome(HttpServletRequest request) {
 		log.info("users.welcome ip: {}, {}, {}, {}", request.getRemoteAddr()
 			, request.getRemoteHost(), request.getRequestURI(), request.getRequestURL());

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -64,6 +64,8 @@ management:
           - beans
           - info
           - busrefresh
+          - prometheus
+          - metrics
   tracing:
     sampling:
       probability: 1.0


### PR DESCRIPTION
## 개요
Microservice 모니터링 환경 구축. Micrometer로 메트릭을 수집하고 Prometheus 스크래핑 → Grafana 대시보드로 시각화한다.

## 변경 사항
- **Micrometer**: `user-service`에 `spring-boot-starter-aop` 추가, `@Timed`(`users.status`, `users.welcome`) 커스텀 메트릭 적용
- **Prometheus**: `apigateway`/`order`/`user-service`에 `micrometer-registry-prometheus` 추가, Actuator `prometheus`/`metrics` 엔드포인트 노출
- **API Gateway**: `/user-service/actuator/**` 전용 라우트 추가 + `AuthorizationHeaderFilter` JWT 검증 우회 → 인증 없이 메트릭 수집 가능
- **Grafana**: Prometheus 데이터소스 연결 및 대시보드 구성 (로컬 환경)

## 참고
- Prometheus/Grafana 설치·대시보드 설정은 외부(로컬) 환경에서 수행되어 저장소에는 미포함

closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)